### PR TITLE
Support ADP spares

### DIFF
--- a/check_netapp_ontap.pl
+++ b/check_netapp_ontap.pl
@@ -25,7 +25,7 @@ use Getopt::Long;
 use POSIX;
 
 # do not show smartmatch warnings
-no warnings 'experimental::smartmatch';
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
 
 my $verbose = undef;
 my $debug = undef;
@@ -222,6 +222,53 @@ sub get_spare_info {
 				$hshSpareInfo{$nodeName}{$strSpareName}{'zeroed'} = $zeroed;
 			} else {
 				next SPARE;
+			}
+		}
+	}
+
+	# Include ADP spares, which are only reported under aggregate spares (not in the spare container)
+	$nahSpareIterator = NaElement->new("aggr-spare-get-iter");
+	$nahQuery = NaElement->new("query");
+	$nahSpareInfo = NaElement->new("storage-disk-info");
+	$nahSpareOwnerInfo = NaElement->new("disk-ownership-info");
+	$strActiveTag = "";
+
+	if (defined($strVHost)) {
+		$nahSpareIterator->child_add($nahQuery);
+		$nahQuery->child_add($nahSpareInfo);
+		$nahSpareInfo->child_add($nahSpareOwnerInfo);
+		$nahSpareOwnerInfo->child_add_string("original-owner", $strVHost);
+	}
+
+	while(defined($strActiveTag)) {
+		if ($strActiveTag ne "") {
+			$nahSpareIterator->child_add_string("tag", $strActiveTag);
+		}
+
+		$nahSpareIterator->child_add_string("max-records", 600);
+		my $nahResponse = $nahStorage->invoke_elem($nahSpareIterator);
+		validate_ontapi_response($nahResponse, "Failed filer health query: ");
+
+		$strActiveTag = $nahResponse->child_get_string("next-tag");
+
+		if ($nahResponse->child_get_string("num-records") == 0) {
+			last;
+		}
+
+		SPARE:
+		foreach my $nahSpare ($nahResponse->child_get("attributes-list")->children_get()) {
+			my $strSpareName = $nahSpare->child_get_string("disk");
+			my $strUsableBlk = $nahSpare->child_get_string("local-usable-data-size-blks");
+
+			# Skip root partition spares
+			if (!defined($strUsableBlk)) {
+				next SPARE;
+			} else {
+				my $nodeName = $nahSpare->child_get_string("original-owner");
+				my $zeroed = $nahSpare->child_get_string('is-disk-zeroed');
+
+				$hshSpareInfo{$nodeName}{$strSpareName}{'status'} = 'spare';
+				$hshSpareInfo{$nodeName}{$strSpareName}{'zeroed'} = $zeroed;
 			}
 		}
 	}


### PR DESCRIPTION
CDOT with Advanced Drive Partitioning (typical in AFF configurations) doesn't report spares in a separate spares container. They can only be accessed at the Aggregate level (aggr-spare-get-iter).

Also fixing a compatibility issue with older perl.